### PR TITLE
Logo downloadable in jpg and png format

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,7 +36,8 @@
             <text class="college-name" dominant-baseline="middle" fill="rgb(103, 108, 114)" font-family="Product Sans" font-size="50" x="230" y="204">{college-name-here}</text>
         </svg>
         <br>
-        <button class="download">Download</button>
+        <button class="download">Download PNG</button>
+        <button class="download">Download JPEG</button>
         <canvas style="display: none;"></canvas>
     </div>
     <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -24,17 +24,28 @@
           const canvas = view.getElementsByTagName("canvas")[0];
           const svg = view.getElementsByTagName("svg")[0];
           if (first) {
-              const button = view.getElementsByTagName("button")[0];
-              button.addEventListener('click', () => {
-                  var image = canvas.toDataURL("image/png");
+              const buttonJPG = view.getElementsByTagName("button")[1];
+              const buttonPNG = view.getElementsByTagName("button")[0];
+              buttonJPG.addEventListener('click', () => {
+                  var image = canvas.toDataURL("image/jpeg");
                   let tmp = document.createElement('a');
-                  tmp.download = "dsclogo.png";
+                  tmp.download = "dsclogo.jpeg";
                   tmp.href = image;
 
                   document.body.appendChild(tmp);
                   tmp.click();
                   document.body.removeChild(tmp);
               });
+              buttonPNG.addEventListener('click', () => {
+                var image = canvas.toDataURL("image/png");
+                let tmp = document.createElement('a');
+                tmp.download = "dsclogo.png";
+                tmp.href = image;
+
+                document.body.appendChild(tmp);
+                tmp.click();
+                document.body.removeChild(tmp);
+            });
           }
           const ctx = canvas.getContext('2d');
           v = canvg.Canvg.fromString(ctx, svg.outerHTML);


### PR DESCRIPTION
GDSC logo is now downloadable in PNG in JPEG format and also logo view size increased in mobile view.